### PR TITLE
Add branch options

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,6 +3,6 @@ version: 2.1
 jobs:
   build:
     docker:
-      - image: circleci/purposeful_failure:2.4.1
+      - image: circleci/ruby:2.4.1
     steps:
       - run: echo success

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,6 +3,6 @@ version: 2.1
 jobs:
   build:
     docker:
-      - image: circleci/ruby:2.4.1
+      - image: busybox:latest
     steps:
       - run: echo success

--- a/Makefile
+++ b/Makefile
@@ -12,5 +12,5 @@ lint-tests:
 	isort --check-only --recursive circleci
 
 unit-tests:
-	pytest circleci/test.py --cov=circleci --circle-token ${CIRCLE_TOKEN} \
+	pytest -s circleci/test.py --cov=circleci --circle-token ${CIRCLE_TOKEN} \
 	--cache-clear --show-capture=stderr --disable-warnings -vv

--- a/README.md
+++ b/README.md
@@ -27,12 +27,13 @@ This is a list of the available tasks:
 
 ### `is_workflow_success`
 
-This will check whether the latest workflow completed successfully in CircleCI. 
+This will check whether the latest workflow completed successfully in CircleCI.
 
 | Parameters   | Required | Description                                              |
 |--------------|----------|----------------------------------------------------------|
 | repository   | yes      | The repository to check for a sucessful workflow status. |
 | circle-token | yes      | A personal API token to access the CircleCI API.         |
+| branch       | yes      | The branch to check aganist.                             |
 
 The returned value is a string data type that will either be `True` or `False`.
 
@@ -46,6 +47,7 @@ This will check whether the latest commit happened recently in GitHub. The lates
 |------------|----------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | repository | yes      | The public repository to check for a recent commit.                                                                                                                |
 | recent     | yes      | The period used to define whether a commit happened recently. The time value must be in a key-value pair format (i.e. `weeks=1, days=1, hours=1, minutes=1`, etc.) |
+| branch     | yes      | The branch to check aganist.                                                                                                                                       |
 
 The returned value is a string data type that will either be `True` or `False`.
 
@@ -59,8 +61,9 @@ This will trigger a project build in CircleCI.
 |--------------|----------|--------------------------------------------------|
 | repository   | yes      | The repository to build.                         |
 | circle-token | yes      | A personal API token to access the CircleCI API. |
+| branch       | yes      | A personal API token to access the CircleCI API. |
 
-The returned value is a string data type. If the project build was triggered, the value will be `True`, otherwise `False`. 
+The returned value is a string data type. If the project build was triggered, the value will be `True`, otherwise `False`.
 
 <br>
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ This will check whether the latest workflow completed successfully in CircleCI.
 |--------------|----------|----------------------------------------------------------------------------------------|
 | repository   | yes      | The repository to check for a sucessful workflow status.                               |
 | circle-token | yes      | A personal API token to access the CircleCI API.                                       |
-| branch       | no       | The branch to check aganist. If none is specified, uses default branch for repository. |
+| branch       | no       | The branch to check against. If none is specified, uses default branch for repository. |
 
 The returned value is a string data type that will either be `True` or `False`.
 
@@ -47,7 +47,7 @@ This will check whether the latest commit happened recently in GitHub. The lates
 |------------|----------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | repository | yes      | The public repository to check for a recent commit.                                                                                                                |
 | recent     | yes      | The period used to define whether a commit happened recently. The time value must be in a key-value pair format (i.e. `weeks=1, days=1, hours=1, minutes=1`, etc.) |
-| branch     | no       | The branch to check aganist. If none is specified, uses default branch for repository.                                                                             |
+| branch     | no       | The branch to check against. If none is specified, uses default branch for repository.                                                                             |
 
 The returned value is a string data type that will either be `True` or `False`.
 
@@ -61,7 +61,7 @@ This will trigger a project build in CircleCI.
 |--------------|----------|------------------------------------------------------------------------------------------------------|
 | repository   | yes      | The repository to build.                                                                             |
 | circle-token | yes      | A personal API token to access the CircleCI API.                                                     |
-| branch       | no       | The branch to check aganist. If none is specified, uses default branch for repository.               |
+| branch       | no       | The branch to check against. If none is specified, uses default branch for repository.               |
 
 The returned value is a string data type. If the project build was triggered, the value will be `True`, otherwise `False`.
 

--- a/README.md
+++ b/README.md
@@ -29,11 +29,11 @@ This is a list of the available tasks:
 
 This will check whether the latest workflow completed successfully in CircleCI.
 
-| Parameters   | Required | Description                                              |
-|--------------|----------|----------------------------------------------------------|
-| repository   | yes      | The repository to check for a sucessful workflow status. |
-| circle-token | yes      | A personal API token to access the CircleCI API.         |
-| branch       | yes      | The branch to check aganist.                             |
+| Parameters   | Required | Description                                                                            |
+|--------------|----------|----------------------------------------------------------------------------------------|
+| repository   | yes      | The repository to check for a sucessful workflow status.                               |
+| circle-token | yes      | A personal API token to access the CircleCI API.                                       |
+| branch       | no       | The branch to check aganist. If none is specified, uses default branch for repository. |
 
 The returned value is a string data type that will either be `True` or `False`.
 
@@ -47,7 +47,7 @@ This will check whether the latest commit happened recently in GitHub. The lates
 |------------|----------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | repository | yes      | The public repository to check for a recent commit.                                                                                                                |
 | recent     | yes      | The period used to define whether a commit happened recently. The time value must be in a key-value pair format (i.e. `weeks=1, days=1, hours=1, minutes=1`, etc.) |
-| branch     | yes      | The branch to check aganist.                                                                                                                                       |
+| branch     | no       | The branch to check aganist. If none is specified, uses default branch for repository.                                                                             |
 
 The returned value is a string data type that will either be `True` or `False`.
 
@@ -57,11 +57,11 @@ The returned value is a string data type that will either be `True` or `False`.
 
 This will trigger a project build in CircleCI.
 
-| Parameters   | Required | Description                                      |
-|--------------|----------|--------------------------------------------------|
-| repository   | yes      | The repository to build.                         |
-| circle-token | yes      | A personal API token to access the CircleCI API. |
-| branch       | yes      | A personal API token to access the CircleCI API. |
+| Parameters   | Required | Description                                                                                          |
+|--------------|----------|------------------------------------------------------------------------------------------------------|
+| repository   | yes      | The repository to build.                                                                             |
+| circle-token | yes      | A personal API token to access the CircleCI API.                                                     |
+| branch       | no       | The branch to check aganist. If none is specified, uses default branch for repository.               |
 
 The returned value is a string data type. If the project build was triggered, the value will be `True`, otherwise `False`.
 
@@ -91,6 +91,7 @@ jobs:
           task: is_workflow_success
           repository: ${{ github.repository }}
           circle-token: ${{ secrets.CIRCLE_TOKEN }}
+          branch: main
 
       - if: contains(steps.is_workflow_success.outputs.value, 'True')
         name: Check for recent commit to Featuretools.

--- a/circleci/__init__.py
+++ b/circleci/__init__.py
@@ -1,3 +1,3 @@
 # flake8:noqa
-from .api import latest_commit, latest_workflow, project_build
+from .api import latest_commit, latest_workflow, project_build, default_branch
 from .utils import is_recent_commit, is_workflow_success

--- a/circleci/api.py
+++ b/circleci/api.py
@@ -48,8 +48,6 @@ def latest_workflow(repository, circle_token="", status="completed",
 def project_build(repository, circle_token="", branch=None):
     if branch is None:
         branch = default_branch(repository)
-        # CircleCI API requires url-encoded branch
-        branch = urllib.parse.quote(branch)
     url = CIRCLE_API
     url += f"/project/github/{repository}/build?circle-token={circle_token}"
     response = requests.post(url, data={"branch": branch})

--- a/circleci/api.py
+++ b/circleci/api.py
@@ -1,6 +1,7 @@
+import urllib.parse
+
 import pandas as pd
 import requests
-import urllib.parse
 
 CIRCLE_API = "https://circleci.com/api/v1.1"
 

--- a/circleci/api.py
+++ b/circleci/api.py
@@ -5,11 +5,12 @@ CIRCLE_API = "https://circleci.com/api/v1.1"
 
 
 def latest_commit(repository, branch=None):
-    data = {}
+    params = {}
     if branch is not None:
-        data["sha"] = branch
+        params["sha"] = branch
     url = "https://api.github.com/repos/%s/commits" % repository
-    response = requests.get(url, data=data)
+    print(params)
+    response = requests.get(url, params=params)
     info = "%s (%s)" % (response.reason, response.status_code)
     assert response.status_code == 200, info
     json = response.json()

--- a/circleci/api.py
+++ b/circleci/api.py
@@ -17,7 +17,8 @@ def latest_commit(repository, branch=None):
     return commit
 
 
-def latest_workflow(repository, circle_token="", status="completed", branch="main"):
+def latest_workflow(repository, circle_token="", status="completed",
+                    branch="main"):
     url = CIRCLE_API + "/project/github/{0}/tree"
     url += "/{4}?circle-token={1}&filter={2}"
     url = url.format(repository, circle_token, status, branch)

--- a/circleci/api.py
+++ b/circleci/api.py
@@ -4,45 +4,48 @@ import requests
 CIRCLE_API = "https://circleci.com/api/v1.1"
 
 
-def latest_commit(repository):
+def latest_commit(repository, branch=None):
+    data = {}
+    if branch is not None:
+        data["sha"] = branch
     url = "https://api.github.com/repos/%s/commits" % repository
-    response = requests.get(url)
-    info = '%s (%s)' % (response.reason, response.status_code)
+    response = requests.get(url, data=data)
+    info = "%s (%s)" % (response.reason, response.status_code)
     assert response.status_code == 200, info
     json = response.json()
-    commit = json[0]['commit']
+    commit = json[0]["commit"]
     return commit
 
 
-def latest_workflow(repository, circle_token='', status='completed', branch="main"):
+def latest_workflow(repository, circle_token="", status="completed", branch="main"):
     url = CIRCLE_API + "/project/github/{0}/tree"
-    url += '/{4}?circle-token={1}&filter={2}'
+    url += "/{4}?circle-token={1}&filter={2}"
     url = url.format(repository, circle_token, status, branch)
     response = requests.get(url)
-    info = '%s (%s)' % (response.reason, response.status_code)
+    info = "%s (%s)" % (response.reason, response.status_code)
     assert response.status_code == 200, info
     integration_tests = response.json()
-    assert integration_tests, 'no integration tests found'
-    keys = ['workflow_id', 'workflow_name', 'job_name']
+    assert integration_tests, "no integration tests found"
+    keys = ["workflow_id", "workflow_name", "job_name"]
 
     records = []
     for test in integration_tests:
-        record = test['workflows']
+        record = test["workflows"]
         record = {key: record[key] for key in keys}
-        record['status'] = test['status']
+        record["status"] = test["status"]
         records.append(record)
 
-    df, key = pd.DataFrame(records), 'workflow_id'
+    df, key = pd.DataFrame(records), "workflow_id"
     workflows, workflow_id = df.groupby(key, sort=False), df[key][0]
     workflow = workflows.get_group(workflow_id)
     return workflow
 
 
-def project_build(repository, circle_token='', branch=None):
+def project_build(repository, circle_token="", branch=None):
     url = CIRCLE_API + "/project/github/{0}/build?circle-token={1}"
     if branch is not None:
         url += "?branch={}".format(branch)
     response = requests.post(url.format(repository, circle_token))
-    info = '%s (%s)' % (response.reason, response.status_code)
+    info = "%s (%s)" % (response.reason, response.status_code)
     assert response.status_code == 200, info
-    return response.json()['body']
+    return response.json()["body"]

--- a/circleci/api.py
+++ b/circleci/api.py
@@ -22,10 +22,12 @@ def latest_workflow(repository, circle_token="", status="completed",
                     branch="main"):
     url = CIRCLE_API + f"/project/github/{repository}/tree"
     url += f"/{branch}?circle-token={circle_token}&filter={status}"
+    print(url)
     response = requests.get(url)
     info = "%s (%s)" % (response.reason, response.status_code)
     assert response.status_code == 200, info
     integration_tests = response.json()
+    print(integration_tests)
     assert integration_tests, "no integration tests found"
     keys = ["workflow_id", "workflow_name", "job_name"]
 

--- a/circleci/api.py
+++ b/circleci/api.py
@@ -48,6 +48,8 @@ def latest_workflow(repository, circle_token="", status="completed",
 def project_build(repository, circle_token="", branch=None):
     if branch is None:
         branch = default_branch(repository)
+    # CircleCI API requires url-encoded branch
+    branch = urllib.parse.quote_plus(branch)
     url = CIRCLE_API
     url += f"/project/github/{repository}/build?circle-token={circle_token}"
     response = requests.post(url, data={"branch": branch})

--- a/circleci/api.py
+++ b/circleci/api.py
@@ -1,5 +1,6 @@
 import pandas as pd
 import requests
+import urllib.parse
 
 CIRCLE_API = "https://circleci.com/api/v1.1"
 
@@ -20,12 +21,13 @@ def latest_commit(repository, branch=None):
 
 def latest_workflow(repository, circle_token="", status="completed",
                     branch="main"):
+    branch = urllib.parse.quote(branch)
     url = CIRCLE_API + f"/project/github/{repository}/tree"
     url += f"/{branch}?circle-token={circle_token}&filter={status}"
-    print(url)
     response = requests.get(url)
     info = "%s (%s)" % (response.reason, response.status_code)
     assert response.status_code == 200, info
+    print(response.json())
     integration_tests = response.json()
     assert integration_tests, "no integration tests found"
     keys = ["workflow_id", "workflow_name", "job_name"]
@@ -44,8 +46,9 @@ def latest_workflow(repository, circle_token="", status="completed",
 
 
 def project_build(repository, circle_token="", branch=None):
-    url = CIRCLE_API + "/project/github/{0}/build?circle-token={1}"
+    url = CIRCLE_API + f"/project/github/{repository}/build?circle-token={circle_token}"
     if branch is not None:
+        branch = urllib.parse.quote(branch)
         url += "?branch={}".format(branch)
     response = requests.post(url.format(repository, circle_token))
     info = "%s (%s)" % (response.reason, response.status_code)

--- a/circleci/api.py
+++ b/circleci/api.py
@@ -23,7 +23,7 @@ def latest_workflow(repository, circle_token="", status="completed",
     if branch is None:
         branch = default_branch(repository)
     # CircleCI API requires url-encoded branch
-    branch = urllib.parse.quote(branch)
+    branch = urllib.parse.quote_plus(branch)
     url = CIRCLE_API + f"/project/github/{repository}/tree"
     url += f"/{branch}?circle-token={circle_token}&filter={status}"
     response = requests.get(url)

--- a/circleci/api.py
+++ b/circleci/api.py
@@ -27,7 +27,6 @@ def latest_workflow(repository, circle_token="", status="completed",
     info = "%s (%s)" % (response.reason, response.status_code)
     assert response.status_code == 200, info
     integration_tests = response.json()
-    print(integration_tests)
     assert integration_tests, "no integration tests found"
     keys = ["workflow_id", "workflow_name", "job_name"]
 

--- a/circleci/api.py
+++ b/circleci/api.py
@@ -50,7 +50,8 @@ def project_build(repository, circle_token="", branch=None):
         branch = default_branch(repository)
         # CircleCI API requires url-encoded branch
         branch = urllib.parse.quote(branch)
-    url = CIRCLE_API + f"/project/github/{repository}/build?circle-token={circle_token}"
+    url = CIRCLE_API
+    url += f"/project/github/{repository}/build?circle-token={circle_token}"
     response = requests.post(url, data={"branch": branch})
     info = "%s (%s)" % (response.reason, response.status_code)
     assert response.status_code == 200, info

--- a/circleci/api.py
+++ b/circleci/api.py
@@ -14,10 +14,10 @@ def latest_commit(repository):
     return commit
 
 
-def latest_workflow(repository, circle_token='', status='completed'):
+def latest_workflow(repository, circle_token='', status='completed', branch="main"):
     url = CIRCLE_API + "/project/github/{0}/tree"
-    url += '/master?circle-token={1}&filter={2}'
-    url = url.format(repository, circle_token, status)
+    url += '/{4}?circle-token={1}&filter={2}'
+    url = url.format(repository, circle_token, status, branch)
     response = requests.get(url)
     info = '%s (%s)' % (response.reason, response.status_code)
     assert response.status_code == 200, info
@@ -38,8 +38,10 @@ def latest_workflow(repository, circle_token='', status='completed'):
     return workflow
 
 
-def project_build(repository, circle_token=''):
+def project_build(repository, circle_token='', branch=None):
     url = CIRCLE_API + "/project/github/{0}/build?circle-token={1}"
+    if branch is not None:
+        url += "?branch={}".format(branch)
     response = requests.post(url.format(repository, circle_token))
     info = '%s (%s)' % (response.reason, response.status_code)
     assert response.status_code == 200, info

--- a/circleci/api.py
+++ b/circleci/api.py
@@ -19,9 +19,8 @@ def latest_commit(repository, branch=None):
 
 def latest_workflow(repository, circle_token="", status="completed",
                     branch="main"):
-    url = CIRCLE_API + "/project/github/{0}/tree"
-    url += "/{4}?circle-token={1}&filter={2}"
-    url = url.format(repository, circle_token, status, branch)
+    url = CIRCLE_API + f"/project/github/{repository}/tree"
+    url += f"/{branch}?circle-token={circle_token}&filter={status}"
     response = requests.get(url)
     info = "%s (%s)" % (response.reason, response.status_code)
     assert response.status_code == 200, info

--- a/circleci/test.py
+++ b/circleci/test.py
@@ -3,7 +3,7 @@ import pytest
 from . import latest_commit, latest_workflow, project_build
 from .utils import is_recent_commit, is_workflow_success
 
-REPOSITORY = "featurelabs/gh-action-circleci"
+REPOSITORY = "FeatureLabs/gh-action-circleci"
 
 
 @pytest.fixture()
@@ -12,12 +12,12 @@ def circle_token(pytestconfig):
 
 
 def test_latest_commit():
-    commit = latest_commit("featurelabs/featuretools")
+    commit = latest_commit("FeatureLabs/featuretools")
     assert "author" in commit and "date" in commit["author"]
 
 
 def test_latest_commit_branch():
-    commit = latest_commit("featurelabs/featuretools", branch="v0.1.10")
+    commit = latest_commit("FeatureLabs/featuretools", branch="v0.1.10")
     assert "tree" in commit and "sha" in commit["tree"]
     assert commit["tree"]["sha"] == "ff46c8939833d022809d11694409eb1c0a18653f"
     assert "ace8d51435fe484476182e908c1ecf9515ec4918" in commit["url"]
@@ -37,7 +37,7 @@ def test_project_build(circle_token, branch):
 
 
 def test_recent_commit():
-    commit = latest_commit("featurelabs/featuretools")
+    commit = latest_commit("FeatureLabs/featuretools")
     recent = is_recent_commit(commit, recent="weeks=100000000")
     assert recent
 

--- a/circleci/test.py
+++ b/circleci/test.py
@@ -46,13 +46,6 @@ def test_workflow_failure(circle_token):
     assert not success
 
 
-def test_workflow_branch(circle_token):
-    workflow = latest_workflow(
-        REPOSITORY, circle_token, status="failed", branch="v1"
-    )
-    print(workflow)
-
-
 def test_workflow_success(circle_token):
     workflow = latest_workflow(REPOSITORY, circle_token, status="successful")
     success = is_workflow_success(workflow)

--- a/circleci/test.py
+++ b/circleci/test.py
@@ -48,7 +48,7 @@ def test_workflow_failure(circle_token):
 
 def test_workflow_branch(circle_token):
     workflow = latest_workflow(
-        REPOSITORY, circle_token, status="failed", branch="v0.1.10"
+        REPOSITORY, circle_token, status="failed", branch="v1"
     )
     print(workflow)
 

--- a/circleci/test.py
+++ b/circleci/test.py
@@ -41,12 +41,14 @@ def test_recent_commit():
 
 
 def test_workflow_failure(circle_token):
-    workflow = latest_workflow(REPOSITORY, circle_token, status="failed")
+    workflow = latest_workflow(REPOSITORY, circle_token, status="failed",
+                               branch='main')
     success = is_workflow_success(workflow)
     assert not success
 
 
 def test_workflow_success(circle_token):
-    workflow = latest_workflow(REPOSITORY, circle_token, status="successful")
+    workflow = latest_workflow(REPOSITORY, circle_token, status="successful",
+                               branch='main')
     success = is_workflow_success(workflow)
     assert success

--- a/circleci/test.py
+++ b/circleci/test.py
@@ -29,8 +29,10 @@ def test_not_recent_commit():
     assert not recent
 
 
-def test_project_build(circle_token):
-    response = project_build(REPOSITORY, circle_token)
+@pytest.mark.parametrize("branch", [(None), ("main"), ("v1")])
+def test_project_build(circle_token, branch):
+    response = project_build(REPOSITORY, circle_token,
+                             branch=branch)
     assert response == "Build created"
 
 
@@ -40,15 +42,17 @@ def test_recent_commit():
     assert recent
 
 
-def test_workflow_failure(circle_token):
+@pytest.mark.parametrize("branch", [(None), ("main"), ("failed_workflow")])
+def test_workflow_failure(circle_token, branch):
     workflow = latest_workflow(REPOSITORY, circle_token, status="failed",
-                               branch='main')
+                               branch=branch)
     success = is_workflow_success(workflow)
     assert not success
 
 
-def test_workflow_success(circle_token):
+@pytest.mark.parametrize("branch", [(None), ("main"), ("v1")])
+def test_workflow_success(circle_token, branch):
     workflow = latest_workflow(REPOSITORY, circle_token, status="successful",
-                               branch='main')
+                               branch=branch)
     success = is_workflow_success(workflow)
     assert success

--- a/circleci/test.py
+++ b/circleci/test.py
@@ -3,7 +3,7 @@ import pytest
 from . import latest_commit, latest_workflow, project_build
 from .utils import is_recent_commit, is_workflow_success
 
-REPOSITORY = 'featurelabs/gh-action-circleci'
+REPOSITORY = "featurelabs/gh-action-circleci"
 
 
 @pytest.fixture()
@@ -12,34 +12,40 @@ def circle_token(pytestconfig):
 
 
 def test_latest_commit():
-    commit = latest_commit('featurelabs/featuretools')
-    assert 'author' in commit and 'date' in commit['author']
+    commit = latest_commit("featurelabs/featuretools")
+    assert "author" in commit and "date" in commit["author"]
+
+
+def test_latest_commit_branch():
+    commit = latest_commit("featurelabs/featuretools", branch="v0.1.10")
+    assert "tree" in commit and "sha" in commit["tree"]
+    assert commit["tree"]["sha"] == "ace8d51435fe484476182e908c1ecf9515ec4918"
 
 
 def test_not_recent_commit():
-    commit = {'author': {'date': '1970-01-01'}}
-    recent = is_recent_commit(commit, recent='days=7')
+    commit = {"author": {"date": "1970-01-01"}}
+    recent = is_recent_commit(commit, recent="days=7")
     assert not recent
 
 
 def test_project_build(circle_token):
     response = project_build(REPOSITORY, circle_token)
-    assert response == 'Build created'
+    assert response == "Build created"
 
 
 def test_recent_commit():
-    commit = latest_commit('featurelabs/featuretools')
-    recent = is_recent_commit(commit, recent='weeks=100000000')
+    commit = latest_commit("featurelabs/featuretools")
+    recent = is_recent_commit(commit, recent="weeks=100000000")
     assert recent
 
 
 def test_workflow_failure(circle_token):
-    workflow = latest_workflow(REPOSITORY, circle_token, status='failed')
+    workflow = latest_workflow(REPOSITORY, circle_token, status="failed")
     success = is_workflow_success(workflow)
     assert not success
 
 
 def test_workflow_success(circle_token):
-    workflow = latest_workflow(REPOSITORY, circle_token, status='successful')
+    workflow = latest_workflow(REPOSITORY, circle_token, status="successful")
     success = is_workflow_success(workflow)
     assert success

--- a/circleci/test.py
+++ b/circleci/test.py
@@ -45,6 +45,13 @@ def test_workflow_failure(circle_token):
     assert not success
 
 
+def test_workflow_branch(circle_token):
+    workflow = latest_workflow(
+        REPOSITORY, circle_token, status="failed", branch="v0.1.10"
+    )
+    print(workflow)
+
+
 def test_workflow_success(circle_token):
     workflow = latest_workflow(REPOSITORY, circle_token, status="successful")
     success = is_workflow_success(workflow)

--- a/circleci/test.py
+++ b/circleci/test.py
@@ -19,7 +19,8 @@ def test_latest_commit():
 def test_latest_commit_branch():
     commit = latest_commit("featurelabs/featuretools", branch="v0.1.10")
     assert "tree" in commit and "sha" in commit["tree"]
-    assert commit["tree"]["sha"] == "ace8d51435fe484476182e908c1ecf9515ec4918"
+    assert commit["tree"]["sha"] == "ff46c8939833d022809d11694409eb1c0a18653f"
+    assert "ace8d51435fe484476182e908c1ecf9515ec4918" in commit["url"]
 
 
 def test_not_recent_commit():

--- a/circleci/test.py
+++ b/circleci/test.py
@@ -1,6 +1,6 @@
 import pytest
 
-from . import latest_commit, latest_workflow, project_build
+from . import default_branch, latest_commit, latest_workflow, project_build
 from .utils import is_recent_commit, is_workflow_success
 
 REPOSITORY = "FeatureLabs/gh-action-circleci"
@@ -56,3 +56,8 @@ def test_workflow_success(circle_token, branch):
                                branch=branch)
     success = is_workflow_success(workflow)
     assert success
+
+
+def test_default_branch():
+    branch = default_branch(REPOSITORY)
+    assert branch == "main"

--- a/circleci/utils.py
+++ b/circleci/utils.py
@@ -3,7 +3,7 @@ from datetime import datetime, timedelta  # noqa
 from dateutil.parser import parse
 
 
-class colors:
+class Colors:
     END = '\033[0m'
     GREEN = '\033[92m'
     RED = '\033[91m'
@@ -22,12 +22,12 @@ def is_recent_commit(commit, recent):
     message = commit.get('message', '')
     message = message.splitlines()[:1]
     message = message.pop() if message else ''
-    message = colors.YELLOW + message + colors.END
+    message = Colors.YELLOW + message + Colors.END
 
     relative = str(elapsed).split('.')[0]
     relative = relative.replace(',', '')
-    color = colors.GREEN if recent else colors.RED
-    relative = color + relative + colors.END
+    color = Colors.GREEN if recent else Colors.RED
+    relative = color + relative + Colors.END
     print(info.format(message, relative))
     return recent
 

--- a/main.py
+++ b/main.py
@@ -8,7 +8,7 @@ def main():
     task.add_argument('repository')
     task.add_argument('--recent', default='days=30')
     task.add_argument('--circle-token')
-    task.add_argument('--branch')
+    task.add_argument('--branch', default=None)
     task = task.parse_args()
 
     if task.name == 'is_workflow_success':

--- a/main.py
+++ b/main.py
@@ -8,20 +8,23 @@ def main():
     task.add_argument('repository')
     task.add_argument('--recent', default='days=30')
     task.add_argument('--circle-token')
+    task.add_argument('--branch')
     task = task.parse_args()
 
     if task.name == 'is_workflow_success':
-        workflow = circleci.latest_workflow(task.repository, task.circle_token)
+        workflow = circleci.latest_workflow(task.repository, task.circle_token,
+                                            task.branch)
         success = circleci.is_workflow_success(workflow)
         print("::set-output name=value::%s" % success)
 
     elif task.name == 'is_recent_commit':
-        commit = circleci.latest_commit(task.repository)
+        commit = circleci.latest_commit(task.repository, task.branch)
         recent = circleci.is_recent_commit(commit, recent=task.recent)
         print("::set-output name=value::%s" % recent)
 
     elif task.name == 'project_build':
-        response = circleci.project_build(task.repository, task.circle_token)
+        response = circleci.project_build(task.repository, task.circle_token,
+                                          task.branch)
         print("::set-output name=value::%s" % response == 'Build created')
         print(response)
 


### PR DESCRIPTION
- Add option to specify branch to run against for Tasks (is_workflow_success, project_build, is_recent_commit)
- Add instructions to readme
- Add to `main.py` to allow Github actions to pass `branch` argument, defaults to None (which uses default repo branch)